### PR TITLE
Backwards compatible CSRF fix for Magento 2.3

### DIFF
--- a/Controller/Ipn/Index.php
+++ b/Controller/Ipn/Index.php
@@ -16,7 +16,7 @@ use Coinpayments\CoinPayments\Helper\Data as CoinPaymentHelper;
  *
  * @package Firebear\CoinPayments\Controller\Ipn
  */
-class Index extends \Magento\Framework\App\Action\Action
+class Index extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
 {
     /**
      * @var \Magento\Sales\Model\OrderRepository
@@ -51,8 +51,19 @@ class Index extends \Magento\Framework\App\Action\Action
         $this->log = $logger;
         $this->helper = $helper;
         parent::__construct($context);
+        
     }
-
+    public function createCsrfValidationException(\Magento\Framework\App\RequestInterface $request): ?\Magento\Framework\App\Request\InvalidRequestException
+        {
+            return null;
+        }
+        
+    public function validateForCsrf(\Magento\Framework\App\RequestInterface $request): ?bool
+        {
+            return true;
+        }
+    
+    
     public function execute()
     {
         if ($this->getRequest()->getParams()) {

--- a/Controller/Ipn/Index.php
+++ b/Controller/Ipn/Index.php
@@ -10,13 +10,15 @@ use Magento\Sales\Model\Order;
 use Magento\Framework\App\Action\Context;
 use Coinpayments\CoinPayments\Logger\Logger;
 use Coinpayments\CoinPayments\Helper\Data as CoinPaymentHelper;
+use Magento\Framework\App\Request\Http as HttpRequest;
+
 
 /**
  * Class Index
  *
  * @package Firebear\CoinPayments\Controller\Ipn
  */
-class Index extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
+class Index extends \Magento\Framework\App\Action\Action
 {
     /**
      * @var \Magento\Sales\Model\OrderRepository
@@ -47,21 +49,21 @@ class Index extends \Magento\Framework\App\Action\Action implements \Magento\Fra
         Logger $logger,
         CoinPaymentHelper $helper
     ) {
+        parent::__construct($context);
+        
         $this->orderRepository = $orderRepository;
         $this->log = $logger;
         $this->helper = $helper;
-        parent::__construct($context);
+        // Fix for Magento2.3 adding isAjax to the request params
+        if(interface_exists("\Magento\Framework\App\CsrfAwareActionInterface")) {
+            $request = $this->getRequest();
+            if ($request instanceof HttpRequest && $request->isPost()) {
+                $request->setParam('isAjax', true);
+            }
+        }
+        
         
     }
-    public function createCsrfValidationException(\Magento\Framework\App\RequestInterface $request): ?\Magento\Framework\App\Request\InvalidRequestException
-        {
-            return null;
-        }
-        
-    public function validateForCsrf(\Magento\Framework\App\RequestInterface $request): ?bool
-        {
-            return true;
-        }
     
     
     public function execute()


### PR DESCRIPTION
Magento 2.3 throws a 302 if no valid form_key is present in the a POST to a controller.
Coinpayments is using a controller for processing IPNS. The IPN functionality hence broke in M2.3.

The solution is to set a header field 'isAjax'.
Setting isAjax prevents CSRF checks to throw a 302 and is backwards compatible with Magento 2.2/2.1

Source: https://github.com/Adyen/adyen-magento2/pull/357