### PR TITLE
Fixing module display on admin

### DIFF
--- a/Model/Api/Base.php
+++ b/Model/Api/Base.php
@@ -82,10 +82,10 @@ class Base
     {
         $paymentConf = $this->getPaymentConfig();
         $baseConf = $this->getBaseConfig();
-        
+
         $paymentConf['public_key'] = isset($paymentConf['public_key']) ? $paymentConf['public_key'] : '';
         $paymentConf['api_version'] = isset($paymentConf['api_version']) ? $paymentConf['api_version'] : '1';
-        
+
         $additionalData = [
             'version' => $baseConf['api_version'],
             'cmd' => $cmd,
@@ -112,7 +112,7 @@ class Base
     public function generateHmac($data, $secretKey = null)
     {
         if (!$secretKey) {
-            $secretKey = $this->getPaymentConfig('secret_key');
+            $secretKey = $this->getPaymentConfig('secret_key') ?: '';
         }
         return hash_hmac('sha512', http_build_query($data), $secretKey);
     }


### PR DESCRIPTION
Fixed exception:

```
#90 {main} {"exception":"[object] (Exception(code: 0): Deprecated Functionality: hash_hmac(): Passing null to parameter #3 ($key) of type string is deprecated in /bitnami/magento/vendor/coinpaymentsnet/magento2/Model/Api/Base.php on line 117 at /bitnami/magento/vendor/magento/framework/App/ErrorHandler.php:62)"} []
```