### PR TITLE
Fix for better compatibility with other payment methods

### DIFF
--- a/view/frontend/web/template/payment/coin_payment_form.html
+++ b/view/frontend/web/template/payment/coin_payment_form.html
@@ -15,8 +15,7 @@
                             enable: 1,
                             options: getAcceptedCurrencies(),
                             optionsValue: 'value',
-                            optionsText: 'name',
-                            optionsCaption: $t('Currency')">
+                            optionsText: 'name'">
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Removed placeholder 'Currency' from cryptocurrency dropdown to fix issues with other payment methods. Even though a customer wanted to pay with another payment method, they still needed to select a cryptocurrency from the dropdown menu in order to place their order.