### PR TITLE
Revert "Fix for better compatibility with other payment methods"

### DIFF
--- a/view/frontend/web/template/payment/coin_payment_form.html
+++ b/view/frontend/web/template/payment/coin_payment_form.html
@@ -15,7 +15,8 @@
                             enable: 1,
                             options: getAcceptedCurrencies(),
                             optionsValue: 'value',
-                            optionsText: 'name'">
+                            optionsText: 'name',
+                            optionsCaption: $t('Currency')">
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Reverts CoinPaymentsNet/coinpayments-magento2#27

Even though this made other payment methods work again, it introduced a new issue for the coinpayments plugin itself. Main fix in next pull request.