### PR TITLE
Update Transaction.php to fix transaction amount error

### DIFF
--- a/Model/Api/Transaction.php
+++ b/Model/Api/Transaction.php
@@ -56,7 +56,8 @@ class Transaction extends Base
     public function create($order, $customerCurrency, $headers = [])
     {
         $data = [
-            'amount' => $this->_rate->getConverted($customerCurrency, $order->getBaseGrandTotal()),
+            //'amount' => $this->_rate->getConverted($customerCurrency, $order->getBaseGrandTotal()),
+            'amount' => $order->getBaseGrandTotal(),
             'currency1' => $this->getPaymentConfig('receive_currency'),
             'currency2' => $customerCurrency,
             'buyer_email' => $order->getCustomerEmail(),


### PR DESCRIPTION
Fix: wrong amount was being sent to API causing the following error showing up: 'Something went wrong: Transaction amount must be greater than 0'